### PR TITLE
ci: add CodeQL security monitoring

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# CodeQL static analysis for the JavaScript/TypeScript Kiwi runtime.
+#
+# All third-party actions are pinned to full commit SHAs (no tag/branch refs,
+# no network resolution at workflow runtime):
+#   - actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+#   - github/codeql-action/{init,autobuild,analyze}@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+# The CodeQL action SHA has init/ and analyze/ action directories verified
+# before pinning. No secrets are used.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "23 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds weekly and PR/push CodeQL analysis for JavaScript/TypeScript. Actions are pinned to full commit SHAs; no secrets or required-check changes.