### PR TITLE
chore(dev): bump @eslint/js to 10.0.1（与 eslint 10 对齐）

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,13 @@ export default [
   },
   js.configs.recommended,
   {
+    // js@10 的 recommended 新增 no-useless-assignment，非项目本意约束。
+    // 后续清理无用赋值后可重新开启此规则。
+    rules: {
+      "no-useless-assignment": "off",
+    },
+  },
+  {
     // Node tooling scripts (fixture generators) run under Node directly.
     files: ["scripts/**/*.mjs"],
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@a2a-js/sdk": "^1.0.1",
-        "@eslint/js": "^9.29.0",
+        "@eslint/js": "^10.0.1",
         "@types/node": "^24.0.0",
         "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
@@ -1082,16 +1082,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@a2a-js/sdk": "^1.0.1",
-    "@eslint/js": "^9.29.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^24.0.0",
     "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^8.34.0",

--- a/src/a2a/node.ts
+++ b/src/a2a/node.ts
@@ -305,6 +305,7 @@ export function resolveA2aThrottle(raw = process.env.KIWI_A2A_THROTTLE ?? ""): T
   } catch (err) {
     throw new Error(
       `KIWI_A2A_THROTTLE 非法: ${v}（可选 "1"/"true"/"on" 用默认档位，或 JSON ThrottleOptions）——${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 }


### PR DESCRIPTION
替代 dependabot PR #2（同目标版本 10.0.1，但 #2 分支基于旧 main、peer 冲突无法通过 CI）。

改动：
- `@eslint/js` ^9.29.0 → ^10.0.1（eslint 本体已由 #5 升到 10.8.1）
- eslint.config.js：`no-useless-assignment` 置 off——js10 recommended 新增、非项目本意约束（留注释，代码清理后重开）
- src/a2a/node.ts：throw 补 `{ cause: err }` 满足 `preserve-caught-error`

本地验证：npm run lint / npm run typecheck 均通过。