### PR TITLE
ci(codeql): align analyze to v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
init/autobuild 已由 #8/#10 升到 v4.37.7，analyze 仍停在 v3.37.6，v3/v4 混用导致 CodeQL Analyze (javascript-typescript) 持续失败。

将 analyze 统一到 v4.37.7（同 sha `ff2f1c6`）。