### PR TITLE
chore(dev): bump @types/node to 26（替代 #4）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@a2a-js/sdk": "^1.0.1",
         "@eslint/js": "^10.0.1",
-        "@types/node": "^24.0.0",
+        "@types/node": "^26.4.1",
         "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
@@ -1844,12 +1844,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -4168,9 +4168,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@a2a-js/sdk": "^1.0.1",
     "@eslint/js": "^10.0.1",
-    "@types/node": "^24.0.0",
+    "@types/node": "^26.4.1",
     "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",

--- a/src/trust/identity/jwk.ts
+++ b/src/trust/identity/jwk.ts
@@ -1,0 +1,10 @@
+/**
+ * JWK（RFC 7517）结构类型。
+ *
+ * @types/node ≥26 不再从 `node:crypto` 顶层导出 `JsonWebKey`，改为
+ * `crypto.webcrypto` 命名空间下的 `webcrypto.JsonWebKey`。此处集中 re-export，
+ * 并补 RFC 7517 的 `kid`（W3C JsonWebKey 未含，JWKS 接缝按 kid 匹配需要它）。
+ */
+import type { webcrypto } from "node:crypto";
+
+export type JsonWebKey = webcrypto.JsonWebKey & { kid?: string };

--- a/src/trust/identity/jws.ts
+++ b/src/trust/identity/jws.ts
@@ -26,7 +26,8 @@
  * 「验签 + 卡片绑定」能力，不做强制决策。
  */
 
-import { createPublicKey, KeyObject, type JsonWebKey, verify as nodeVerify } from "node:crypto";
+import { createPublicKey, KeyObject, verify as nodeVerify } from "node:crypto";
+import type { JsonWebKey } from "./jwk.js";
 import { parseAgentCard } from "../../discovery/agent-card/index.js";
 import type { AgentCard } from "../../discovery/agent-card/index.js";
 import { canonicalize } from "../../negotiation/jcs.js";

--- a/src/trust/identity/keys.ts
+++ b/src/trust/identity/keys.ts
@@ -26,7 +26,8 @@
  * 私钥仅存在于出站签名器（signer.ts）；本模块不保存、不解析私钥除外的任何 secret。
  */
 
-import { createPrivateKey, createPublicKey, type JsonWebKey, type KeyObject } from "node:crypto";
+import { createPrivateKey, createPublicKey, type KeyObject } from "node:crypto";
+import type { JsonWebKey } from "./jwk.js";
 import type { TrustLevel } from "./trust-policy.js";
 
 /** 本实现支持的签名算法（RFC 9421 alg 名见 RFC9421_ALG_NAMES）。 */

--- a/src/trust/identity/message-signature.ts
+++ b/src/trust/identity/message-signature.ts
@@ -32,9 +32,9 @@ import {
   createHash,
   sign as nodeSign,
   verify as nodeVerify,
-  type JsonWebKey,
   type KeyObject,
 } from "node:crypto";
+import type { JsonWebKey } from "./jwk.js";
 import type { A2AOutboundRequest } from "../../a2a/client/types.js";
 import {
   buildSignatureBase,


### PR DESCRIPTION
替代 dependabot PR #4。

@types/node 26 移除 `node:crypto` 顶层 `JsonWebKey` 导出（TS2305），改到 `webcrypto` 命名空间；且 W3C 类型缺 RFC 7517 `kid`。

- 新增 `src/trust/identity/jwk.ts`：re-export `webcrypto.JsonWebKey` 并补 `kid`
- `keys.ts` / `jws.ts` / `message-signature.ts` 改从 `./jwk.js` 取类型

验证：`npm run typecheck`（0 错）/ `npm run lint` 通过；签名相关 47 tests 通过。