### PR TITLE
chore(dev): bump typescript to 6.0.3（渐进，替代 #3 TS7）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "jsqr": "^1.4.0",
         "prettier": "^3.5.3",
         "qrcode": "^1.5.4",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -4154,9 +4154,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jsqr": "^1.4.0",
     "prettier": "^3.5.3",
     "qrcode": "^1.5.4",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   },
   "publishConfig": {


### PR DESCRIPTION
替代 dependabot PR #3。

#3 目标 TS 7.0.2 超出 typescript-eslint 支持范围（`@typescript-eslint/parser@8.69.0` peer `typescript >=4.8.4 <6.1.0`，无任何版本支持 TS7），强行升级会摧毁 ESLint TS 检查。改为渐进升至 **6.0.3**——工具链支持的最新 major。

验证：`npm run typecheck` 0 错、`npm run lint` / `npm run build` 通过，无需代码改动。TS7 待 typescript-eslint 适配后小步升级（届时 dependabot 自动重开）。